### PR TITLE
https://github.com/nasa/nos3/issues/351 - Change Inp_DI.txt and SC_NO…

### DIFF
--- a/fsw/cfs/cfg/Inp_DI.txt
+++ b/fsw/cfs/cfg/Inp_DI.txt
@@ -17,5 +17,5 @@
  0.0     1.0     0.0   0.01082       ! Axis in body, Maximum momentum
  0.0     0.0     1.0   0.01082       ! Axis in body, Maximum momentum
 !!!!!!!!!!!!!!! Star Tracker !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
--0.5510871 -0.4059919 -0.5108982 0.5200544 ! Quaternion from sensor to body frame
+0.0 0.0 0.0 1.0 ! Quaternion from sensor to body frame
 


### PR DESCRIPTION
…S3.txt to both use the identity (no) rotation.  This causes the DI quaternion and the truth quaternion to track each other (when the star tracker is valid).